### PR TITLE
Update README.md to fix scoop command

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ yay -S wishlist
 winget install wishlist
 
 # Windows (with Scoop)
-scoop bucket add https://github.com/charmbracelet/scoop-bucket.git
+scoop bucket add charm https://github.com/charmbracelet/scoop-bucket.git
 scoop install wishlist
 
 # Nix


### PR DESCRIPTION
Fixed the example for Windows with scoop using the wrong syntax. 
The scoop add command also requires a name for the bucket: 
```bash
Unknown bucket 'https://github.com/charmbracelet/scoop-bucket.git'. Try specifying <repo>.
usage: scoop bucket add <name> [<repo>]
```
This was not included in the example, so the command would fail. I set the name to `charm` in this PR.